### PR TITLE
chore(sc): fix ContractParam.Integer transformation

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "bs58": "^4.0.1",
     "bs58check": "^2.1.2",
     "crypto-js": "^3.1.9-1",
+    "csbiginteger": "^2.12.0",
     "elliptic": "^6.4.1",
     "js-scrypt": "^0.2.0",
     "loglevel": "^1.6.1",

--- a/src/sc/ScriptBuilder.js
+++ b/src/sc/ScriptBuilder.js
@@ -1,3 +1,4 @@
+import { csBigInteger } from 'csbiginteger'
 import { StringStream, num2hexstring, reverseHex, ensureHex, int2hex, str2ab, ab2hexstring, str2hexstring } from '../utils.js'
 import OpCode from './opCode.js'
 
@@ -72,8 +73,8 @@ class ScriptBuilder extends StringStream {
     if (num === -1) return this.emit(OpCode.PUSHM1)
     if (num === 0) return this.emit(OpCode.PUSH0)
     if (num > 0 && num <= 16) return this.emit(OpCode.PUSH1 - 1 + num)
-    const hexstring = int2hex(num)
-    return this.emitPush(reverseHex(hexstring))
+    const bn = new csBigInteger(num) // eslint-disable-line new-cap
+    return this.emitPush(bn.toHexString())
   }
 
   /**


### PR DESCRIPTION
C# BigInteger uses two's complement which wasn't reflected by the parseInt of javascript. This solution brings in Igor's csbiginteger package which is a javascript implementation of the c# BigInteger class. With this, we should be able to convert correctly. It's a good place to start testing the package out too.

Taken from https://github.com/CityOfZion/neon-js/pull/347.